### PR TITLE
Fix lein command in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,1 @@
 language: clojure
-lein: lein1
-script: lein1 test


### PR DESCRIPTION
For clojure projects, we do not need to specify
the test task as travis ci assumes it as default
https://docs.travis-ci.com/user/languages/clojure/#Default-Test-Script