### PR TITLE
Add support for using akar pattern matching in recursive functions

### DIFF
--- a/src/akar/try_out.clj
+++ b/src/akar/try_out.clj
@@ -4,4 +4,5 @@
   (:require [akar.patterns :refer :all])
   (:require [akar.combinators :refer :all])
   (:require [akar.syntax :refer :all])
+  (:require [akar.util :refer :all])
   (:require [n01se.syntax :refer :all]))

--- a/src/akar/util.clj
+++ b/src/akar/util.clj
@@ -1,0 +1,41 @@
+(ns akar.util
+  (:require [clojure.walk :as cw]))
+
+(defn ^:private postwalk-fn-replace
+  "Calls the matching-fn on every expression and if matching-fn
+   returned true, replaces the expression by the result of calling
+   replacing-fn with the given expr as the parameter"
+  [matching-fn replacing-fn form]
+  (cw/postwalk (fn [x]
+                 (if (matching-fn x)
+                   (replacing-fn x)
+                   x))
+               form))
+
+
+(defmacro defn-trampolined
+  "Given a function body which uses trampolined-recur for
+   recursion (instead of recur), this macro generates a function with
+   given name.
+
+   The generated function accepts the same arguments which are passed to
+   the macro as args parameter. The args parameter is expected to be a vector.
+
+   The macro replaces all the occurrences of trampolined-recur in function
+   body with calls to anonymous function.
+
+   The generated function uses trampoline for recursion.
+
+   If the given function body does not have any trampoline-recur occurrences,
+   the generated function body will be exactly same as passed except
+   for it being wrapped in an anonymous function and called with trampoline."
+  [fn-name args & body]
+  (let [tail-rec-fn-name (symbol (str fn-name "*"))
+        fn-body# (postwalk-fn-replace (fn [expr]
+                                        (and (seq? expr)
+                                             (= (first expr) 'trampolined-recur)))
+                                      (fn [expr]
+                                        `(fn [] ~(cons tail-rec-fn-name (rest expr))))
+                                      (cons 'do body))
+        tramp-fn# `(defn ~fn-name ~args (trampoline (fn ~tail-rec-fn-name ~args ~fn-body#) ~@args))]
+    tramp-fn#))

--- a/test/akar/util_test.clj
+++ b/test/akar/util_test.clj
@@ -1,0 +1,71 @@
+(ns akar.util-test
+  (:require [akar.util :refer :all]
+            [clojure.test :refer :all]
+            [akar.syntax :refer :all]))
+
+(deftest postwalk-fn-replace-test
+  (testing "should replace the expression with result of replacing fn"
+    (let [postwalk-fn-replace #'akar.util/postwalk-fn-replace]
+      (is (= (postwalk-fn-replace (fn [expr]
+                                       (= :a expr))
+                                     (fn [expr]
+                                       :b)
+                                     '(:a :b :c :d))
+             '(:b :b :c :d))))))
+
+
+(deftest defn-trampolined-test
+  (testing "should replace single trampolined-recur call with trampolined function giving correct result"
+    (defn-trampolined tail-recursive-sum [x running-total]
+      (match x
+             0  running-total
+             :_ (trampolined-recur (dec x) (+ running-total x))))
+    (is (= (tail-recursive-sum 10 100)
+           155))
+    ;; these values are simple values which would give stackoverflow error if called without TCO
+    (is (= (tail-recursive-sum 123038 10)
+           7569236251)))
+
+  (testing "should replace all the trampolined-recur calls with trampolined function giving correct result"
+    (defn-trampolined multi-tail-recursive-fn [x y]
+      (match x
+             0  y
+             ;; some random logic here just to have more than one trampolined-recur
+             ;; skips the number 4 for addition
+             5 (trampolined-recur (- x 2) (+ y x))
+             :_ (trampolined-recur (dec x) (+ y x))))
+    (is (= (multi-tail-recursive-fn 3 0)
+           6))
+    (is (= (multi-tail-recursive-fn 10 0)
+           51))
+    (is (= (multi-tail-recursive-fn 10 1)
+           52))
+    (is (= (multi-tail-recursive-fn 123038 10)
+           7569236247)))
+
+  (testing "should not evaluate the side affecting function more than required no of times"
+    (let [some-global-state (atom 0)]
+      (defn-trampolined side-affecting-tail-recursive-sum [some-state x running-total]
+        (match x
+               0  running-total
+               :_ (do
+                    (swap! some-state inc)
+                    (trampolined-recur some-state (dec x) (+ running-total x)))))
+      ;; verify that side affecting operation is not called unless needed
+      (is (= (side-affecting-tail-recursive-sum some-global-state 0 10)
+             10))
+      (is (= 0 @some-global-state))
+      ;; verify that the side affecting operation is not called more than expected no of times
+      (is (= (side-affecting-tail-recursive-sum some-global-state 5 10)
+             25))
+      (is (= 5 @some-global-state))))
+
+  (testing "should not fail when non recursive function given used with defn-trampolined"
+    (defn-trampolined non-tail-recursive-fn [x y]
+      (match x
+             0  y
+             :_ x))
+    (is (= (non-tail-recursive-fn 10 20)
+           10))
+    (is (= (non-tail-recursive-fn 0 20)
+           20))))


### PR DESCRIPTION
Since Akar patterns are first class functions, having recur along with patterns used to cause error as the recur would no longer be in the tail position for the original function.
This commits introduces new construct called `defn-trampolined` to mitigate this issue. We replace the recur occurrences with an anonymous function called using trampoline.

Eg usage

```
(defn-trampolined tail-recursive-sum [x running-total]
      (match x
             0  running-total
             :_ (trampolined-recur (dec x) (+ running-total x))))
```
Please note using `trampolined-recur` instead of `recur` in the body above.

When used like shown above, a function with name `tail-recursive-sum` is generated which internally uses `trampoline` for recursion. 
Hence we get around the `recur` issue caused with `match` achieving the same effect as `recur` .

Relevant tests can be found in `util_test.clj` namespace.

Fixes https://github.com/missingfaktor/akar/issues/14
Related to https://github.com/missingfaktor/akar/issues/11