### PR TITLE
Add gotchas document

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -1,0 +1,22 @@
+# This document lists gotchs for using akar.
+
+* #### Using akar `match` clauses along with `recur`
+Since Akar patterns are first class functions, having `recur` along with akar patterns causes error. This is because the recur would no longer be in the tail position for the original function.
+
+To work around this issue, Akar has a macro called `defn-trampolined`.
+
+The macro removes the `trampolined-recur` occurrences in function body and generates function which uses trampoline to achieve recursion.
+
+Please note we replace `trampolined-recur` and not `recur`. This is done intentionally to avoid having any unintended effect of the replacement.
+
+
+Example usage:
+```
+(defn-trampolined tail-recursive-sum [x running-total]
+      (match x
+             0  running-total
+             :_ (trampolined-recur (dec x) (+ running-total x))))
+
+```
+
+The above definition generates a function with name `tail-recursive-sum` which internally uses [trampoline](https://clojuredocs.org/clojure.core/trampoline) to achieve recursion.

--- a/src/akar/util.clj
+++ b/src/akar/util.clj
@@ -24,11 +24,13 @@
    The macro replaces all the occurrences of trampolined-recur in function
    body with calls to anonymous function.
 
-   The generated function uses trampoline for recursion.
+   The generated function uses trampolining to achieve recursion. In other
+   words, we swap stack for heap for recursive calls.
+   https://clojuredocs.org/clojure.core/trampoline
 
    If the given function body does not have any trampoline-recur occurrences,
    the generated function body will be exactly same as passed except
-   for it being wrapped in an anonymous function and called with trampoline."
+   it will be wrapped in an anonymous function and called with trampoline."
   [fn-name args & body]
   (let [tail-rec-fn-name (symbol (str fn-name "*"))
         fn-body# (postwalk-fn-replace (fn [expr]

--- a/test/akar/util_test.clj
+++ b/test/akar/util_test.clj
@@ -22,7 +22,7 @@
              :_ (trampolined-recur (dec x) (+ running-total x))))
     (is (= (tail-recursive-sum 10 100)
            155))
-    ;; these values are simple values which would give stackoverflow error if called without TCO
+    ;; these values are simple values which would give stackoverflow error if called without defn-trampolimed
     (is (= (tail-recursive-sum 123038 10)
            7569236251)))
 
@@ -60,7 +60,7 @@
              25))
       (is (= 5 @some-global-state))))
 
-  (testing "should not fail when non recursive function given used with defn-trampolined"
+  (testing "should not fail for function with no trampoline-recur occurance"
     (defn-trampolined non-tail-recursive-fn [x y]
       (match x
              0  y


### PR DESCRIPTION
This PR adds a gotchas document to list some gotchas while using akar.
Adds `defn-trampolined` in the gotchas document with example usage.